### PR TITLE
feat: Add `detect-exposed-workflow-secrets` action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,17 +52,15 @@ jobs:
           - name: "ruff"
             commands: |
               tox -e ruff
-          ## TODO: Uncomment `pylint` once the first in-house, Python-based action is merged
-          # - name: "pylint"
-          #   commands: |
-          #     echo "::add-matcher::.github/workflows/matchers/pylint.json"
-          #     tox -e fastlint
-          #     tox -e lint
-          ## TODO: Uncomment `mypy` once the first in-house, Python-based action is merged
-          # - name: "mypy"
-          #   commands: |
-          #     echo "::add-matcher::.github/workflows/matchers/mypy.json"
-          #     tox -e mypy
+          - name: "pylint"
+            commands: |
+              echo "::add-matcher::.github/workflows/matchers/pylint.json"
+              tox -e fastlint
+              tox -e lint
+          - name: "mypy"
+            commands: |
+              echo "::add-matcher::.github/workflows/matchers/mypy.json"
+              tox -e mypy
           - name: "yamllint"
             commands: |
               tox -e yamllint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,6 +102,10 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install tox tox-gh>=1.2
 
+      - name: Run Python unit tests for each GH action
+        run: |
+          tox -e detect-exposed-workflow-secrets
+
       - name: Run Bash "unit" tests with tox on MacOS
         if: startsWith(matrix.platform, 'macos')
         run: |

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -8,3 +8,8 @@ import_heading_firstparty=First Party
 import_heading_localfolder=Local
 known_firstparty=
 known_localfolder=tuning
+
+# isort falsely flags some GitHub action Python files as problematic, and tries to add
+# comments to existing import statements for the wrong reasons. Therefore, we skip these
+# files
+skip_glob=actions/detect-exposed-workflow-secrets/exposed_secrets_detection/*.py

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -12,3 +12,9 @@ rules:
     ignore:
       # REASON: This file needs lines that are longer than 120 in order to load variables to the env
       - /actions/launch-ec2-runner-with-fallback/action.yml
+
+# SKIP running yamllint on these files entirely. Please provide clear, concise reasons.
+ignore:
+    # REASON: This file contains intentionally malformed YAML for testing purposes within the
+    # 'detect-exposed-workflow-secrets' action
+    - /actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_data/git_workflow_invalid_yaml.yml

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## Contents
 - [📙 Overview of this Repository](#-overview-of-this-repository)
 - [👊 Available In-House GitHub Actions](#-available-in-house-github-actions)
+- [❓ How to Use One or More In-House GitHub actions](#-how-to-use-one-or-more-in-house-github-actions)
 - [📬 Contributing](#-contributing)
 
 ## 📙 Overview of this Repository
@@ -15,13 +16,14 @@ Below is a list of the in-house GitHub actions stored in this repository:
 
 | Name | Description | Example Use Cases |
 | --- | --- | --- |
+| [detect-exposed-workflow-secrets](./actions/detect-exposed-workflow-secrets/detect-exposed-workflow-secrets.md) | Used to detect when a contributor's PR would expose a GitHub secret through one or more workflow files that auto-trigger on PRs, and aborts that contributor's PR build before it can start. | <ul><li>Prevent accidental secrets exposure through GitHub workflow files that auto-trigger on PR builds.</li></ul> |
 | [free-disk-space](./actions/free-disk-space/free-disk-space.md) | Used to reclaim disk space on either a GitHub or EC2 runner. | <ul><li>If a CI job tends to fail due to "insufficient disk space"</li><li>If you want to reduce cloud costs by reclaiming disk space instead of increasing your writeable cloud storage to compensate for a bloated EC2 image</li></ul> |
 | [launch-ec2-runner-with-fallback](./actions/launch-ec2-runner-with-fallback/launch-ec2-runner-with-fallback.md) | Used launch an EC2 instance in AWS, either as a spot instance or a dedicated instance. If your preferred availability zone lacks availability for your instance type, "backup" availability zones will be tried. | <ul><li>Insufficient capacity in AWS (i.e., AWS lacks availablility for your desired EC2 instance type in your preferred availability zone)</li><li>Cost savings (i.e., You want to try launching your EC2 runner as a spot instance first)</li></ul> |
 
-## How to Use One or More In-House GitHub Actions
+## ❓ How to Use One or More In-House GitHub Actions
 
 Each GitHub action in this repository contains documentation explaining how to reference and use it in another repo.
 
-## Contributing
+## 📬 Contributing
 
 Check out our [contributing](CONTRIBUTING/CONTRIBUTING.md) guide to learn how to contribute.

--- a/actions/detect-exposed-workflow-secrets/action.yml
+++ b/actions/detect-exposed-workflow-secrets/action.yml
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Detect Exposed Secrets'
+description: 'Detects exposed secrets in the repository'
+runs:
+  using: "composite"
+  steps:
+
+    - name: Checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        # https://github.com/actions/checkout/issues/249
+        fetch-depth: 0
+        # Must set 'path' due to a bug with actions/checkout
+        path: "pull-request-changes"
+
+    - name: Check for exposed secrets in workflow files
+      run: |
+         cd ${{ github.action_path }}/exposed_secrets_detection
+         python3 -m src.main --dir "${GITHUB_WORKSPACE}/pull-request-changes/.github/workflows"
+      shell: bash

--- a/actions/detect-exposed-workflow-secrets/detect-exposed-workflow-secrets.md
+++ b/actions/detect-exposed-workflow-secrets/detect-exposed-workflow-secrets.md
@@ -1,0 +1,37 @@
+# Detect Exposed Workflow Secrets
+
+## Overview
+
+This action detects potentially-exposed GitHub workflow secrets in workflows that automatically trigger on PR builds. If a contributor creates a pull request that would expose one or more GitHub secrets, this action can be used to abort the contributor's PR build and alert maintainers about the potential security exposure.
+
+## When to Use it?
+
+Use this action when you are concerned that a contributor may expose a workflow secret such as a paid API key or login credentials
+
+## How to Call this Action from a Job within a GitHub Workflow 
+
+It is strongly recommended that you add this action within a new or existing lint workflow, and that you require this action to complete before proceeding with unit testing, functional testing, E2E testing, etc.
+
+To call this action, create this basic job definition and put it in one of your lint workflow files:
+
+```yaml
+security-lint:
+  runs-on: ubuntu-latest
+  steps:
+
+    # Clone the `ci-actions` repo to gain access to this action
+    - name: Checkout "detect-exposed-workflow-secrets" in-house CI action
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        # The action is stored in this repository, so we need to tell GitHub to pull from: {org}/{repo}
+        repository: instructlab/ci-actions
+        # clone the "ci-actions" repo to a local directory called "ci-actions", instead of overwriting the current WORKDIR contents
+        path: ci-actions
+        # Only checkout the relevant GitHub action
+        sparse-checkout: |
+          actions/detect-exposed-workflow-secrets
+
+    # Run the secrets detection
+    - name: Detect exposed GitHub secrets
+      uses: ./.github/actions/detect-exposed-workflow-secrets
+```

--- a/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/requirements-dev.txt
+++ b/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+pyyaml

--- a/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/src/cli.py
+++ b/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/src/cli.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+import argparse
+import sys
+
+# Local
+from .custom_exceptions import (
+    GitWorkflowFilesNotFoundError,
+    ExposedSecretsError,
+)
+from .utils import (
+    find_all_yaml_files_in_directory,
+    find_exposed_github_secrets_in_env_block,
+    find_exposed_github_secrets_in_job,
+    get_workflow_trigger_conditions,
+    is_git_workflow_file,
+    load_workflow_file,
+    workflow_auto_triggers_on_pull_request,
+)
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """
+    Generates a parser for the CLI.
+
+    Returns
+    -------
+    parser: argparse.ArgumentParser
+    """
+    parser = argparse.ArgumentParser(
+        prog="Exposed-Secrets-Detection",
+        description="Attempts to find any potentially exposed secrets, and reports them",
+    )
+
+    # User can pass in a directory or file, hence they both have "required=False", but one must be chosen
+    parser.add_argument(
+        "-d",
+        "--dir",
+        type=str,
+        help="Directory to read Git workflow files from",
+        required=False,
+    )
+    parser.add_argument(
+        "-f",
+        "--file",
+        type=str,
+        help="Path to the Git workflow file to read",
+        required=False,
+    )
+
+    return parser
+
+
+def run_validation(args: dict):
+    """
+    Runs validation steps to detect potentially-exposed secrets. In the process, this function also validates
+    that the user has provided at least "--dir" or "--file" as inputs
+
+    Inputs
+    ------
+    args: dict
+        Dictionary of the user's arguments
+    """
+    read_dir = args.get("dir")
+    file_path = args.get("file")
+
+    if not read_dir and not file_path:
+        print(
+            "This tool requires either: a path to a valid Git workflow file or a directory that contains Git workflow files. Detected neither."
+        )
+        sys.exit(1)
+
+    if read_dir and file_path:
+        raise NotImplementedError(
+            "This tool currently does not support both --dir and --file being passed in simultaneously."
+        )
+
+    if read_dir:
+        print(
+            f"Finding GitHub workflow files under {read_dir} and its sub-directories ..."
+        )
+        git_workflow_files = {}
+        yaml_files = find_all_yaml_files_in_directory(read_dir)
+
+        # For each YAML file we've found, store it in a dictionary for later parsing. We need the yaml file *path* as the
+        # key so we can provide actionable error messages if an exception is caught.
+        workflow_files_found = 0
+        for yaml_file in yaml_files:
+            loaded_file = load_workflow_file(yaml_file)
+
+            # Only parse the file if we've confirmed it's a valid Git workflow file and not a random YAML
+            if is_git_workflow_file(loaded_file):
+                git_workflow_files[yaml_file] = loaded_file
+                workflow_files_found += 1
+                print(f"  - Found and loaded workflow file: {yaml_file}")
+
+        if workflow_files_found == 0:
+            raise GitWorkflowFilesNotFoundError(
+                f"YAML files were found under directory '{read_dir}', but none were identified as Git workflow files"
+            )
+
+    if file_path:
+        print(f"Reading Git workflow file {file_path}...")
+        loaded_file = load_workflow_file(file_path)
+
+        # Only parse the file if we've confirmed it's a valid Git workflow file and not a random YAML
+        if not is_git_workflow_file(loaded_file):
+            raise GitWorkflowFilesNotFoundError(
+                f"YAML file '{file_path}' is not recognized as a Git workflow file."
+            )
+        print(f"  - Successfully found and loaded workflow file: {file_path}")
+        git_workflow_files = {file_path: loaded_file}
+
+    # For each workflow file, detect if there are exposed secrets
+    exposed_secrets_by_file = {}
+    print("Reviewing workflow file(s) to find any exposed GitHub secrets...")
+
+    for file_path, file_contents in git_workflow_files.items():
+        # This will find any workflow trigger conditions. If none exist, an error is raised.
+        trigger_conditions = get_workflow_trigger_conditions(file_path, file_contents)
+
+        # If the workflow doesn't automatically trigger on pull requests, then org/repo maintainers don't have to
+        # worry about a bad actor editing the repo contents to retrieve and/or use our GitHub secrets without their
+        # knowledge or consent.
+        if workflow_auto_triggers_on_pull_request(trigger_conditions) is False:
+            filename_without_path = file_path.split("/")[-1]
+            print(
+                f"[NOTE] The following workflow does not automatically trigger on pull requests, so ignoring: {filename_without_path}"
+            )
+            continue
+
+        # Check if "env" exists at the top level and find any secrets
+        top_level_env = file_contents.get("env", {})
+        exposed_secrets = find_exposed_github_secrets_in_env_block(top_level_env)
+
+        # If we've found any exposed secrets, keep track, but don't throw an error. Let's find all errors for
+        # the user first.
+        if len(exposed_secrets) > 0:
+            print(
+                f"[WARNING] Detected exposed top-level env secrets: {exposed_secrets}"
+            )
+            exposed_secrets_by_file.update(
+                {
+                    "filename": file_path,
+                    "job_name": "n/a",
+                    "exposed_secrets": exposed_secrets,
+                }
+            )
+
+        # It's possible that someone's workflow file is a WIP and doesn't have "jobs" defined yet, so don't throw
+        # an error in this case!
+        jobs = file_contents.get("jobs", {})
+        for job_name, job_def in jobs.items():
+            exposed_secrets = find_exposed_github_secrets_in_job(job_def)
+
+            # Same as above. If we find an exposed secret, keep track, but don't fail until the end.
+            if len(exposed_secrets) > 0:
+                print(
+                    f"[WARNING] Detected exposed secrets for job '{job_name}': {exposed_secrets}"
+                )
+                exposed_secrets_by_file.update(
+                    {
+                        "filename": file_path,
+                        "job_name": job_name,
+                        "exposed_secrets": exposed_secrets,
+                    }
+                )
+
+        if len(exposed_secrets_by_file) > 0:
+            raise ExposedSecretsError(
+                f"Detected one or more exposed secrets. Please review the findings below, and if you "
+                f"feel they have been made in error, please file a GitHub issue and link to this job "
+                f"URL. Findings: {exposed_secrets_by_file}"
+            )
+
+    print(
+        "Hooray! There is no concern about exposed secrets in the environment! Carry on..."
+    )

--- a/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/src/custom_exceptions.py
+++ b/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/src/custom_exceptions.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# pylint: disable=W0107  # Disables the pylint check for 'unnecessary pass'
+
+
+class MissingTriggerConditionsError(Exception):
+    "Raised when trigger conditions are not defined in a Git workflow file"
+
+    pass
+
+
+class GitWorkflowFilesNotFoundError(Exception):
+    "Raised when no Git Workflow files are found"
+
+    pass
+
+
+class GitWorkflowFilesSearchError(Exception):
+    "Raised when there was an issue when traversing a directory for git workflow files"
+
+    pass
+
+
+class ExposedSecretsError(Exception):
+    "Raised when exposed secrets are found within a Git workflow file"
+
+    pass

--- a/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/src/main.py
+++ b/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/src/main.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Local
+from .cli import create_parser, run_validation
+
+
+def run():
+    """
+    Run CLI and parse user args
+    """
+    parser = create_parser()
+    args = vars(parser.parse_args())
+    run_validation(args)
+
+
+if __name__ == "__main__":
+    run()

--- a/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/src/utils.py
+++ b/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/src/utils.py
@@ -1,0 +1,256 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Standard
+import os
+import re
+
+# Third-Party
+import yaml
+
+# Local
+from .custom_exceptions import (
+    GitWorkflowFilesNotFoundError,
+    GitWorkflowFilesSearchError,
+    MissingTriggerConditionsError,
+)
+
+
+def load_workflow_file(workflow_filename: str) -> dict:
+    """
+    Loads `workflow_filename` into a dictionary object
+
+    Inputs
+    ------
+    workflow_filename: str
+        The name of the YAML workflow file to load
+
+    Returns
+    -------
+    workflow_file: dict
+        The loaded workflow file, in dictionary format
+    """
+    workflow_file = None
+    try:
+        with open(workflow_filename, "r", encoding="utf-8") as file:
+            workflow_file = yaml.safe_load(file)
+
+    except FileNotFoundError as file_nf_err:
+        print(
+            f"Failed to find workflow file: {workflow_filename}. This is an internal error. "
+            "Please file a GitHub issue if you encounter this error and link to this failed "
+            "job. Most likely, an incorrect filename was referenced due to a typo."
+        )
+        raise file_nf_err
+
+    except OSError as os_err:
+        print(
+            f"Unable to open/read workflow file: {workflow_filename}. This is an internal error. "
+            "Please file a GitHub issue if you encounter this error and link to this failed "
+            "job. It is possible the workflow file is corrupted or a RAM issue was encountered."
+        )
+        raise os_err
+
+    except yaml.YAMLError as yml_err:
+        print(
+            f"Unable to open/read workflow file: {workflow_filename}. Most likely, this error "
+            "occurred because the format of your YAML is invalid. Please ensure your YAML file is "
+            "properly formatted and try again. However, if you have not modified a YAML file in "
+            "your pull request, please file a GitHub issue and link to this failed job."
+        )
+        raise yml_err
+
+    except Exception as ex:
+        print(
+            f"An unknown exception occurred when attempting to load {workflow_filename}. "
+            "This is an internal error. Please file a GitHub issue if you encounter this error, "
+            "link to this failed job, and provide the error message printed to the console below."
+        )
+        raise ex
+
+    return workflow_file
+
+
+def workflow_auto_triggers_on_pull_request(trigger_conditions: list) -> bool:
+    """
+    Detects if a workflow automatically runs on a pull request by default, or requires
+    a maintainer to manually run the job. Some jobs may allow for a combination of manual
+    and automatic triggers, but if any automatic triggers exist, then we return False.
+
+    Inputs
+    ------
+    trigger_conditions: list
+        List of workflow triggers. For example: ["schedule", "workflow_dispatch", "pull_request"]
+
+    Returns
+    -------
+    True/False: bool
+       Returns "True" if the GitHub workflow file can automatically trigger on PR builds
+       without any form of pre-approval from a maintainer.
+    """
+    # These triggers are often used in workflow files to automatically trigger on certain pull
+    # request/issue actions.
+    automatic_triggers = {
+        "issue_comment",  # this can sometimes require a GitHub token stored in an env var
+        "pull_request",
+        "pull_request_comment",  # this is deprecated and replaced by "issue_comment", but GitHub still allows it to be used
+        "pull_request_review",
+        "pull_request_review_comment",
+        "pull_request_target",
+    }
+
+    # If even one of the above triggers is found in the given workflow file, then we must review the
+    # whole workflow to find potential exposed secrets.
+    return bool(set(trigger_conditions) & automatic_triggers)
+
+
+def find_exposed_github_secrets_in_env_block(env_block: dict) -> dict:
+    """
+    Finds any exposed GitHub secrets in an `env` block
+
+    Inputs
+    ------
+    env_block: dict
+        The `env` block to parse
+
+    Returns
+    -------
+    exposed_secrets: dict
+        A dictionary which contains the env var names that have secrets, but does
+        not contain the secrets themselves.
+    """
+    # GitHub secrets follow one of these forms: "${{ secrets.SOME_NAME }}" or "${{ secrets['SOME_NAME'] }}"
+    secrets_regexp = re.compile(r"\$\{\{\s*secrets[\.\[].+\}\}")
+
+    # Contains all detected exposed GitHub secrets
+    exposed_secrets = {}
+
+    for var, value in env_block.items():
+        if secrets_regexp.search(value):
+            print(f"WARNING: Detected exposed GitHub secret: {var}={value}")
+            exposed_secrets[var] = value
+
+    return exposed_secrets
+
+
+def find_exposed_github_secrets_in_job(job: dict) -> dict:
+    """
+    Finds all `env` block definitions in a job within a Git workflow file, then
+    determines if any secrets exist.
+
+    Inputs
+    ------
+    job: dict
+        The job configuration/definition
+
+    Returns
+    -------
+    exposed_secrets: dict
+        A dictionary which contains the env var names that have secrets, but does
+        not contain the secrets themselves.
+    """
+    # Contains all detected exposed GitHub secrets
+    exposed_secrets = {}
+
+    steps = job.get("steps", [])
+    for job_step in steps:
+        env_block = job_step.get("env", {})
+        env_block_exposed_secrets = find_exposed_github_secrets_in_env_block(env_block)
+        exposed_secrets.update(env_block_exposed_secrets)
+
+    return exposed_secrets
+
+
+def find_all_yaml_files_in_directory(dirname: str) -> list[str]:
+    """
+    Finds all yaml files in a given directory and its sub-directories
+
+    Inputs
+    ------
+    dirname: str
+        Directory to search through
+
+    Returns
+    -------
+    yaml_files: list
+        List of the full paths to the YAML files found (if any)
+    """
+    yaml_files = []
+
+    # This theoretically should never throw an exception, even if the directory to search
+    # through does not exist, but a try-except block is added for safety.
+    try:
+        for root, _, files in os.walk(dirname):
+            for filename in files:
+                if filename.endswith((".yaml", ".yml")):
+                    yaml_files.append(os.path.join(root, filename))
+    except Exception as ex:
+        # pylint: disable=W0707  # Ignore re-raise
+        raise GitWorkflowFilesSearchError(
+            f"An unknown error occurred when trying to walk through directory: {dirname}. If "
+            f"you think this is error is incorrect, please file a GitHub issue and provide a "
+            f"link to this failing job alongside a screenshot. Error message returned: {ex}"
+        )
+
+    if len(yaml_files) == 0:
+        raise GitWorkflowFilesNotFoundError(
+            f"No YAML files were found under '{dirname}' or any of its sub-directories."
+        )
+
+    return yaml_files
+
+
+def is_git_workflow_file(yaml_file: dict) -> bool:
+    """
+    Determines if the provided YAML file is a workflow file or not
+
+    Inputs
+    ------
+    yaml_file: dict
+        YAML file that has been loaded and stored as a dictionary
+
+    Returns
+    -------
+    True/False
+    """
+    # All workflow files need the "name" and "jobs" field at a bare minimum
+    return bool("name" in yaml_file and "jobs" in yaml_file)
+
+
+def get_workflow_trigger_conditions(
+    workflow_file_path: str, workflow_file_contents: dict
+) -> list[str]:
+    """
+    Gets the list of trigger conditions for a given workflow.
+
+    Inputs
+    ------
+    workflow_file_path: str
+        Path to the workflow file name. (Mainly used for error handling.)
+    workflow_file_contents: dict
+        Git workflow file contents that were loaded from a YAML file
+
+    Returns
+    -------
+    trigger_conditions: list
+        List of the trigger conditions, but not their configs.
+    """
+    # Note that because GitHub workflow files use the key "on" to denote trigger conditions,
+    # sometimes YAML parsing automatically converts "on" to a boolean value (i.e., "True"
+    # in this case). So we have to check for both conditions.
+    trigger_conditions_dict = workflow_file_contents.get("on", {})
+    if len(trigger_conditions_dict) == 0:
+        trigger_conditions_dict = workflow_file_contents.get(True, {})
+
+    # Sometimes, users may make pull requests that are a WIP and presently missing trigger conditions,
+    # but we should still flag it anyway. We don't want anything flying under the radar.
+    if len(trigger_conditions_dict) == 0:
+        raise MissingTriggerConditionsError(
+            f"Could not identify trigger conditions for Git workflow file: {workflow_file_path}. If you "
+            f"are currently working on updating this workflow in a pull request, then please add one or "
+            f"more valid trigger conditions to your workflow file. If you are NOT updating this "
+            f"workflow file and you feel this error message is incorrect, please file a GitHub issue "
+            f"and link to this job URL, as well as provide a screenshot."
+        )
+
+    trigger_conditions = list(trigger_conditions_dict.keys())
+    return trigger_conditions

--- a/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_cli.py
+++ b/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_cli.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Third-Party
+import pytest
+import yaml
+
+# Local
+from src.custom_exceptions import (
+    ExposedSecretsError,
+    GitWorkflowFilesNotFoundError,
+    MissingTriggerConditionsError,
+)
+from src.cli import (
+    create_parser,
+    run_validation,
+)
+
+
+def test_create_parser_succeeds():
+    create_parser()
+
+
+def test_run_validation_cli_arguments_are_missing():
+    args = {}
+    with pytest.raises(SystemExit):
+        run_validation(args)
+
+
+def test_run_validation_combination_of_cli_arguments_is_unsupported():
+    args = {
+        "file": "some-filename.yml",
+        "dir": "some-directory",
+    }
+    with pytest.raises(NotImplementedError):
+        run_validation(args)
+
+
+def test_run_validation_workflow_file_does_not_exist():
+    args = {
+        "file": "some-nonexistent-file.yml",
+    }
+    with pytest.raises(FileNotFoundError):
+        run_validation(args)
+
+
+def test_run_validation_workflow_directory_does_not_exist():
+    args = {
+        "file": "some-nonexistent-directory/fake-dir",
+    }
+    with pytest.raises(FileNotFoundError):
+        run_validation(args)
+
+
+def test_run_validation_workflow_file_exists_but_has_no_trigger_conditions():
+    args = {
+        "file": "tests/test_data/git_workflow_missing_triggers.yml",
+    }
+    with pytest.raises(MissingTriggerConditionsError):
+        run_validation(args)
+
+
+def test_run_validation_workflow_directory_exists_but_one_file_has_a_yaml_parsing_error():
+    args = {
+        "dir": "tests",
+    }
+    with pytest.raises(yaml.YAMLError):
+        run_validation(args)
+
+
+def test_run_validation_workflow_but_yaml_is_not_a_workflow():
+    args = {
+        "file": "tests/test_data/random_yaml_file.yml",
+    }
+    with pytest.raises(
+        GitWorkflowFilesNotFoundError,
+        match=r"YAML file 'tests/test_data/random_yaml_file.yml' is not recognized as a Git workflow file.",
+    ):
+        run_validation(args)
+
+
+def test_run_validation_workflow_is_manual_and_secrets_are_not_exposed():
+    args = {
+        "file": "tests/test_data/git_workflow_manual_trigger.yml",
+    }
+    # We don't need to assert anything here. Any secrets exposed will throw an exception.
+    run_validation(args)
+
+
+def test_run_validation_workflow_has_top_level_secrets():
+    args = {
+        "file": "tests/test_data/git_workflow_automatic_trigger_with_top_level_env_secrets.yaml",
+    }
+    # Assert we find a 'SECRET_TOKEN' and 'SECRET_KEY' loaded into the env, and see 'n/a' as the job name
+    with pytest.raises(
+        ExposedSecretsError,
+        match=r"Detected one or more exposed secrets.*Findings:.*'job_name': 'n/a'.*secrets.SECRET_TOKEN.*secrets.SECRET_KEY.*",
+    ):
+        run_validation(args)
+
+
+def test_run_validation_workflow_is_automatic_and_secrets_are_exposed():
+    args = {
+        "file": "tests/test_data/git_workflow_automatic_trigger.yaml",
+    }
+    # Assert we find a 'SECRET_TOKEN' and 'SECRET_KEY' loaded into the env
+    with pytest.raises(
+        ExposedSecretsError,
+        match=r"Detected one or more exposed secrets.*Findings:.*secrets.SECRET_TOKEN.*secrets.SECRET_KEY.*",
+    ):
+        run_validation(args)

--- a/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_data/dummy_dir/git_workflow_automatic_trigger_nested_subdir.yaml
+++ b/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_data/dummy_dir/git_workflow_automatic_trigger_nested_subdir.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# yamllint disable rule:line-length
+
+name: "Fake E2E Job"
+
+on:
+  pull_request_target:
+    branches:
+      - main
+      - release-*
+  
+jobs:
+  fake-e2e-test:
+    needs:
+      - start-fake-ec2-runner
+    runs-on: ${{ needs.start-fake-ec2-runner.outputs.label }}
+
+    steps:
+      - name: Run e2e test
+        env:
+          # <<< Exposed Secrets >>>
+          SECRET_TOKEN: ${{ secrets.SECRET_TOKEN }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+        run: |
+          sh some_script.sh

--- a/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_data/git_workflow_automatic_trigger.yaml
+++ b/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_data/git_workflow_automatic_trigger.yaml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0
+# yamllint disable rule:line-length
+
+name: "Fake E2E Job"
+
+on:
+  pull_request_target:
+    branches:
+      - main
+      - release-*
+  
+jobs:
+  fake-e2e-test:
+    needs:
+      - start-fake-ec2-runner
+    runs-on: ${{ needs.start-fake-ec2-runner.outputs.label }}
+
+    steps:
+      - name: Run e2e test
+        env:
+          # <<< Exposed Secrets >>>
+          SECRET_TOKEN: ${{ secrets.SECRET_TOKEN }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+        run: |
+          sh some_script.sh d

--- a/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_data/git_workflow_automatic_trigger_with_top_level_env_secrets.yaml
+++ b/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_data/git_workflow_automatic_trigger_with_top_level_env_secrets.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# yamllint disable rule:line-length
+
+name: "Fake E2E Job"
+
+on:
+  pull_request_target:
+    branches:
+      - main
+      - release-*
+
+env:
+  # <<< Exposed Secrets >>>
+  SECRET_TOKEN: ${{ secrets.SECRET_TOKEN }}
+  SECRET_KEY: ${{ secrets.SECRET_KEY }}
+
+jobs:
+  fake-e2e-test:
+    needs:
+      - start-fake-ec2-runner
+    runs-on: ${{ needs.start-fake-ec2-runner.outputs.label }}
+
+    steps:
+      - name: Run e2e test
+        run: |
+          sh some_script.sh

--- a/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_data/git_workflow_invalid_yaml.yml
+++ b/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_data/git_workflow_invalid_yaml.yml
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+# yamllint disable rule:line-length
+
+name: "Fake E2E Job with Invalid YAML formatting"
+
+on:
+  schedule:
+    - cron: '0 11 * * *' # Runs at 11AM UTC every day
+  workflow_dispatch:
+
+    # Invalid YAML because of this indentation error
+        inputs:
+      pr_or_branch:
+        description: 'pull request number or branch name'
+        required: true
+        default: 'main'
+
+jobs:
+    # Invalid YAML because of this indentation error too
+        start-fake-ec2-runner:
+    outputs:
+      label: ${{ steps.start-ec2-runner.outputs.label }}
+      ec2-instance-id: ${{ steps.start-ec2-runner.outputs.ec2-instance-id }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 # v4.0.3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Start EC2 runner
+        id: start-ec2-runner
+        uses: machulav/ec2-github-runner@fcfb31a5760dad1314a64a0e172b78ec6fc8a17e # v2.3.6
+        with:
+          mode: start
+          github-token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
+          ec2-image-id: ${{ vars.AWS_EC2_AMI }}
+          ec2-instance-type: g6e.12xlarge
+          subnet-id: subnet-0123456abc
+          security-group-id: sg-0123456abc
+          iam-role-name: instructlab-ci-runner
+          aws-resource-tags: >
+            [
+              {"Key": "SomeKey", "Value": "SomeValue"},
+              {"Key": "SomeOtherKey", "Value": "SomeOtherValue"},
+            ]

--- a/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_data/git_workflow_manual_trigger.yml
+++ b/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_data/git_workflow_manual_trigger.yml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+# yamllint disable rule:line-length
+
+name: "Fake E2E Job"
+
+on:
+  workflow_dispatch:
+    inputs:
+      some_input:
+        description: 'Some input'
+        required: true
+      some_other_input:
+        description: 'some other input'
+        required: false
+
+jobs:
+  fake-e2e-test:
+    needs:
+      - start-fake-ec2-runner
+    runs-on: ${{ needs.start-fake-ec2-runner.outputs.label }}
+
+    steps:
+      - name: Run e2e test
+        env:
+          SECRET_TOKEN: ${{ secrets.SECRET_TOKEN }}
+          SECRET_KEY: ${{ secrets.SECRET_KEY }}
+        run: |
+          sh some_script.sh

--- a/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_data/git_workflow_missing_triggers.yml
+++ b/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_data/git_workflow_missing_triggers.yml
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# yamllint disable rule:line-length
+
+name: "Fake E2E Job with Missing Job Triggers"
+
+# TRIGGERS ARE INTENTIONALLY MISSING
+
+jobs:
+  fake-e2e-test:
+    needs:
+      - start-fake-ec2-runner
+    runs-on: ${{ needs.start-fake-ec2-runner.outputs.label }}
+
+    steps:
+      - name: Run e2e test
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          sh some_script.sh

--- a/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_data/random_yaml_file.yml
+++ b/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_data/random_yaml_file.yml
@@ -1,0 +1,4 @@
+some-key:
+  some-sub-key:
+    - some-val1
+    - some-val2

--- a/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_utils.py
+++ b/actions/detect-exposed-workflow-secrets/exposed_secrets_detection/tests/test_utils.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: Apache-2.0
+
+# Third-Party
+import pytest
+from yaml import YAMLError
+
+# Local
+from src.utils import (
+    find_all_yaml_files_in_directory,
+    find_exposed_github_secrets_in_env_block,
+    find_exposed_github_secrets_in_job,
+    get_workflow_trigger_conditions,
+    is_git_workflow_file,
+    load_workflow_file,
+    workflow_auto_triggers_on_pull_request,
+)
+from src.custom_exceptions import (
+    GitWorkflowFilesNotFoundError,
+    MissingTriggerConditionsError,
+)
+
+
+def test_load_workflow_file_fails_because_file_does_not_exist():
+    with pytest.raises(
+        FileNotFoundError,
+        match=r"No such file or directory: 'non-existent-file'",
+    ):
+        load_workflow_file("non-existent-file")
+
+
+def test_load_workflow_file_fails_for_malformed_file():
+    with pytest.raises(YAMLError):
+        load_workflow_file("tests/test_data/git_workflow_invalid_yaml.yml")
+
+
+def test_load_workflow_file_for_valid_workflow():
+    load_workflow_file("tests/test_data/git_workflow_manual_trigger.yml")
+
+
+def test_get_workflow_trigger_conditions_for_valid_workflow_file():
+    test_workflow_file_path = "some-workflow.yml"
+    valid_workflow_file = {
+        "name": "Valid fake E2E Job",
+        "on": {
+            "schedule": [{"cron": "0 11 * * *"}],
+            "workflow_dispatch": {
+                "inputs": {
+                    "pr_or_branch": {
+                        "description": "pull request number or branch name",
+                        "required": True,
+                        "default": "main",
+                    },
+                },
+            },
+        },
+        "jobs": {},  # doesn't matter if it's empty for this test
+    }
+    trigger_conditions = get_workflow_trigger_conditions(
+        test_workflow_file_path, valid_workflow_file
+    )
+    expected_trigger_conditions = ["schedule", "workflow_dispatch"]
+
+    assert len(trigger_conditions) == 2
+    assert sorted(trigger_conditions) == sorted(expected_trigger_conditions)
+
+
+def test_get_workflow_trigger_conditions_for_valid_workflow_file_with_yaml_parse_conversion_to_True():
+    test_workflow_file_path = "some-workflow.yml"
+    valid_workflow_file = {
+        "name": "Valid fake E2E Job",
+        True: {
+            "schedule": [{"cron": "0 11 * * *"}],
+            "workflow_dispatch": {
+                "inputs": {
+                    "pr_or_branch": {
+                        "description": "pull request number or branch name",
+                        "required": True,
+                        "default": "main",
+                    },
+                },
+            },
+        },
+        "jobs": {},  # doesn't matter if it's empty for this test
+    }
+    trigger_conditions = get_workflow_trigger_conditions(
+        test_workflow_file_path, valid_workflow_file
+    )
+    expected_trigger_conditions = ["schedule", "workflow_dispatch"]
+
+    assert len(trigger_conditions) == 2
+    assert sorted(trigger_conditions) == sorted(expected_trigger_conditions)
+
+
+def test_get_workflow_trigger_conditions_from_workflow_missing_trigger_conditions():
+    test_workflow_file_path = "some-workflow.yml"
+    invalid_workflow_file = {
+        "name": "Invalid E2E job missing trigger conditions",
+        "jobs": {},  # doesn't matter if it's empty for this test
+    }
+    with pytest.raises(MissingTriggerConditionsError):
+        get_workflow_trigger_conditions(test_workflow_file_path, invalid_workflow_file)
+
+
+def test_workflow_auto_triggers_on_pull_request_no_automatic_triggers_exist():
+    trigger_conditions = [
+        "schedule",
+        "workflow_dispatch",
+    ]
+    workflow_contains_auto_triggers = workflow_auto_triggers_on_pull_request(
+        trigger_conditions
+    )
+    assert workflow_contains_auto_triggers is False  # noqa: E712
+
+
+def test_workflow_auto_triggers_on_pull_request_one_automatic_trigger_exists():
+    trigger_conditions = [
+        "schedule",
+        "workflow_dispatch",
+        "pull_request",
+    ]
+    workflow_contains_auto_triggers = workflow_auto_triggers_on_pull_request(
+        trigger_conditions
+    )
+    assert workflow_contains_auto_triggers is True  # noqa: E712
+
+
+def test_find_exposed_secrets_in_env_block_empty():
+    env_block = {}
+    exposed_secrets = find_exposed_github_secrets_in_env_block(env_block)
+    assert len(exposed_secrets) == 0
+
+
+def test_find_exposed_secrets_in_env_block_no_github_secrets():
+    env_block = {"VAR1": "value1", "VAR2": "value2"}
+    exposed_secrets = find_exposed_github_secrets_in_env_block(env_block)
+    assert len(exposed_secrets) == 0
+
+
+def test_find_exposed_secrets_in_env_block_found_one_secret():
+    env_block = {
+        "VAR1": "value1",
+        "VAR2": "value2",
+        "SECRET_TOKEN": "${{ secrets.SECRET_TOKEN }}",
+    }
+    exposed_secrets = find_exposed_github_secrets_in_env_block(env_block)
+    expected_exposed_secrets = {
+        "SECRET_TOKEN": "${{ secrets.SECRET_TOKEN }}",
+    }
+
+    assert len(exposed_secrets) == 1
+    assert exposed_secrets == expected_exposed_secrets
+
+
+def test_find_exposed_secrets_in_env_block_found_mulitple_secrets():
+    env_block = {
+        "VAR1": "value1",
+        "VAR2": "value2",
+        "SECRET_TOKEN": "${{ secrets.SECRET_TOKEN }}",
+        "SECRET_KEY": "${{ secrets.SECRET_KEY }}",
+        "SECRET_PASSWORD": "${{ secrets['SECRET_PASSWORD'] }}",
+    }
+    exposed_secrets = find_exposed_github_secrets_in_env_block(env_block)
+    expected_exposed_secrets = {
+        "SECRET_TOKEN": "${{ secrets.SECRET_TOKEN }}",
+        "SECRET_KEY": "${{ secrets.SECRET_KEY }}",
+        "SECRET_PASSWORD": "${{ secrets['SECRET_PASSWORD'] }}",
+    }
+
+    assert len(exposed_secrets) == 3
+    assert exposed_secrets == expected_exposed_secrets
+
+
+def test_find_exposed_github_secrets_in_job_no_env_vars():
+    job_with_no_env_vars = {
+        "start-fake-ec2-runner": {
+            "outputs": {
+                "label": "${{ steps.start-ec2-runner.outputs.label }}",
+                "ec2-instance-id": "${{ steps.start-ec2-runner.outputs.ec2-instance-id }}",
+            },
+            "runs-on": "ubuntu-latest",
+            "steps": [
+                {
+                    "name": "Step 1",
+                    "uses": "aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9",
+                    "with": {
+                        "aws-access-key-id": "${{ secrets.AWS_ACCESS_KEY_ID }}",
+                        "aws-secret-access-key": "${{ secrets.AWS_SECRET_ACCESS_KEY }}",
+                        "aws-region": "us-east-1",
+                    },
+                },
+            ],
+        },
+    }
+    exposed_secrets = find_exposed_github_secrets_in_job(job_with_no_env_vars)
+    assert len(exposed_secrets) == 0
+
+
+def test_find_exposed_github_secrets_in_job_env_vars_exist_but_no_secrets_exposed():
+    job_with_env_vars_but_no_exposed_secrets = {
+        "needs": [
+            "start-fake-ec2-runner",
+        ],
+        "runs-on": "${{ needs.start-fake-ec2-runner.outputs.label }}",
+        "steps": [
+            {
+                "name": "Step 1",
+                "run": "echo 'hello'",
+                "env": {"VAR1": "value1", "VAR2": "value2"},
+            },
+        ],
+    }
+    exposed_secrets = find_exposed_github_secrets_in_job(
+        job_with_env_vars_but_no_exposed_secrets
+    )
+    assert len(exposed_secrets) == 0
+
+
+def test_find_exposed_github_secrets_in_job_env_vars_exist_two_secrets_exposed():
+    job_with_exposed_secrets_in_env = {
+        "needs": [
+            "start-fake-ec2-runner",
+        ],
+        "runs-on": "${{ needs.start-fake-ec2-runner.outputs.label }}",
+        "steps": [
+            {
+                "name": "Step 1",
+                "run": "echo 'hello'",
+                "env": {
+                    "SECRET_TOKEN": "${{ secrets.SECRET_TOKEN }}",
+                    "SECRET_KEY": "${{ secrets.SECRET_KEY }}",
+                    "SOME_VARIABLE": "test-value",
+                },
+            },
+        ],
+    }
+    exposed_secrets = find_exposed_github_secrets_in_job(
+        job_with_exposed_secrets_in_env
+    )
+    expected_exposed_secrets = {
+        "SECRET_TOKEN": "${{ secrets.SECRET_TOKEN }}",
+        "SECRET_KEY": "${{ secrets.SECRET_KEY }}",
+    }
+    assert len(exposed_secrets) == 2
+    assert exposed_secrets == expected_exposed_secrets
+
+
+def test_find_all_yaml_files_in_directory_no_yaml_files():
+    with pytest.raises(
+        GitWorkflowFilesNotFoundError,
+        match=r"No YAML files were found under 'src' or any of its sub-directories",
+    ):
+        find_all_yaml_files_in_directory("src")
+
+
+def test_find_all_yaml_files_in_directory_but_directory_does_not_exist():
+    with pytest.raises(
+        GitWorkflowFilesNotFoundError,
+        match=r"No YAML files were found under 'nonexistent-dir' or any of its sub-directories",
+    ):
+        find_all_yaml_files_in_directory("nonexistent-dir")
+
+
+# Note: We presently have three test YAML files under `tests/test_data`
+def test_find_all_yaml_files_in_directory_with_no_trailing_slash():
+    yaml_files = find_all_yaml_files_in_directory("tests")
+    assert len(yaml_files) > 0
+
+
+# Note: We presently have three test YAML files under `tests/test_data`
+def test_find_all_yaml_files_in_directory_with_trailing_slash():
+    yaml_files = find_all_yaml_files_in_directory("tests/")
+    assert len(yaml_files) > 0
+
+
+def test_is_git_workflow_file_not_a_workflow_file():
+    non_workflow_file = {
+        "some-key": {
+            "sub-key-1": [
+                "something",
+                "something-else",
+            ],
+            "sub-key-2": "some-val",
+        },
+        "jobs": {},
+    }
+    is_valid_workflow = is_git_workflow_file(non_workflow_file)
+    assert is_valid_workflow is False  # noqa: E712
+
+
+def test_is_git_workflow_file_is_valid_file():
+    valid_workflow_file = {
+        "name": "Valid fake E2E Job",
+        "on": {
+            "schedule": [{"cron": "0 11 * * *"}],
+            "workflow_dispatch": {
+                "inputs": {
+                    "pr_or_branch": {
+                        "description": "pull request number or branch name",
+                        "required": True,
+                        "default": "main",
+                    },
+                },
+            },
+        },
+        "jobs": {},  # doesn't matter if it's empty for this test
+    }
+    is_valid_workflow = is_git_workflow_file(valid_workflow_file)
+    assert is_valid_workflow is True  # noqa: E712

--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,16 @@ basepython = python3.11
 [testenv:py3-unit]
 basepython = {[testenv:py3]basepython}
 
+[testenv:detect-exposed-workflow-secrets]
+description = run Python unit tests (unit, unitcov)
+change_dir = actions/detect-exposed-workflow-secrets/exposed_secrets_detection/
+deps = 
+    pytest-cov
+    -r actions/detect-exposed-workflow-secrets/exposed_secrets_detection/requirements-dev.txt
+commands =
+    {envpython} -m pytest {posargs:tests}
+    {envpython} -W error::UserWarning -m pytest --cov=src
+
 # format, check, and linting targets don't build and install the project to
 # speed up testing.
 [testenv:lint]
@@ -28,9 +38,11 @@ deps =
     pytest
     pylint>=2.16.2,<4.0
     pylint-pydantic
-## TODO: Update directories from `src/` and `test/` so the proper dirs can be linted
+    pyyaml
+
 commands =
-    {envpython} -m pylint --load-plugins pylint_pydantic src/ tests/
+    # detect-exposed-workflow-secrets
+    {envpython} -m pylint --load-plugins pylint_pydantic actions/detect-exposed-workflow-secrets/exposed_secrets_detection
 
 [testenv:fastlint]
 description = fast lint with pylint (without 3rd party modules)
@@ -44,7 +56,7 @@ commands =
     {envpython} -m pylint \
         --load-plugins pylint_pydantic \
         --disable=import-error \
-        src/ tests/
+        actions
 
 [testenv:ruff]
 description = lint and format check with ruff
@@ -93,7 +105,7 @@ deps =
   pytest
   pydantic<=2.9.2
 commands =
-  mypy {posargs}
+  mypy {posargs} actions
 
 # This test environment is separate for 'launch-ec2-runner-with-fallback' rather than being a
 # generic "bash" test env. We need the 'change_dir' specified for each bash test. Unfortunately,


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #7 

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

**Integration Testing Evidence**
- Link to pull request(s):
  - https://github.com/instructlab/instructlab/pull/3228

- Links to passing CI job(s):
  - https://github.com/instructlab/instructlab/actions/runs/13812194181/job/38636162468?pr=3228

**Checklist:**

- [x] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/ci-actions/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [x] Documentation has been added and/or updated, if applicable.
- [x] Unit tests have been added and/or updated. (If this is not applicable, please provide a justification.)
- [x] Integration testing has been performed, if applicable

## Description of this Change

This action is used to detect accidentally-exposed GitHub workflow secrets. For example, printing out a secret variable within a workflow that automatically triggers on PR builds.