### PR TITLE
chore: run action tests when calling `tox`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [tox]
-# py3-unit runs unit tests with 'python3'
-# py311-unit runs the same tests with 'python3.11'
-envlist = ruff, lint, mypy, py3-unit
+envlist = ruff, lint, mypy, detect-exposed-workflow-secrets, launch-ec2-runner-with-fallback
 minversion = 4.4
-
-[testenv]
-description = run tests (unit, unitcov)
-deps = -r requirements-dev.txt
-commands =
-    unit: {envpython} -m pytest {posargs:tests}
-    unitcov: {envpython} -W error::UserWarning -m pytest --cov=src --cov-report term --cov-report=html:coverage-{env_name} --cov-report=xml:coverage-{env_name}.xml --html=durations/{env_name}.html {posargs:tests -m "not (examples or slow)"}
 
 [testenv:py3]
 basepython = python3.11
 
-[testenv:py3-unit]
-basepython = {[testenv:py3]basepython}
-
 [testenv:detect-exposed-workflow-secrets]
-description = run Python unit tests (unit, unitcov)
+description = run Python unit tests
 change_dir = actions/detect-exposed-workflow-secrets/exposed_secrets_detection/
 deps = 
     pytest-cov
@@ -118,8 +106,3 @@ change_dir = actions/launch-ec2-runner-with-fallback/tests/
 commands =
   # "UNIT" TESTS: launch-ec2-runner-with-fallback
   ./test_get_config_value.sh
-
-[gh]
-python =
-    3.11 = py311-unitcov
-    3.10 = py310-unitcov


### PR DESCRIPTION
This also cleans up a bunch of crust for non-existing targets like unit.

Signed-off-by: Ihar Hrachyshka <ihar.hrachyshka@gmail.com>

<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

<!-- Uncomment this section if your pull request contains code changes and you have tested them against 1 or more InstructLab repositories
**Integration Testing Evidence**
- Link to pull request(s):
  - link
  - link

- Links to passing CI job(s):
  - link
  - link
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/ci-actions/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been added and/or updated, if applicable.
- [ ] Unit tests have been added and/or updated. (If this is not applicable, please provide a justification.)
- [ ] Integration testing has been performed, if applicable

## Description of this Change

<!-- Provide a brief description of your pull request, at least 1-2 sentences. This description should explain the motivation and value of your CI action. --->
