### PR TITLE
fix(launch-ec2-runner-with-fallback): Always check if an instance is launched + perform cleanup

### DIFF
--- a/actions/launch-ec2-runner-with-fallback/action.yml
+++ b/actions/launch-ec2-runner-with-fallback/action.yml
@@ -561,8 +561,10 @@ runs:
         iam-role-name: instructlab-ci-runner
         aws-resource-tags: ${{ inputs.aws_resource_tags }}
 
-    # Output the EC2 runner label and instance ID to the 'selected-availability-zone' ID output for reference later.
+    # Output the EC2 runner label and instance ID to the 'selected-availability-zone' ID output for reference later. Note
+    # that we always want to run this job to cleanup instances in AWS in case the instance launching gets aborted prematurely.
     - name: Determine EC2 availability zone used
+      if: ${{ always() }}
       id: selected-availability-zone
       shell: bash
       run: |


### PR DESCRIPTION
<!-- Thank you for contributing to InstructLab! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Add a link to any related Dev Doc or Dev Doc PR in https://github.com/instructlab/dev-docs (if there is no related Dev Doc, **remove that section**)
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

<!-- Uncomment this section if any existing or in-flight Dev Docs are related to this change
**Dev Docs related to this Pull Request:**
Link to Dev Doc or PR: 
--->

<!-- Uncomment this section if your pull request contains code changes and you have tested them against 1 or more InstructLab repositories
**Integration Testing Evidence**
- Link to pull request(s):
  - link
  - link

- Links to passing CI job(s):
  - link
  - link
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [ ] [Changelog](https://github.com/instructlab/ci-actions/blob/main/CHANGELOG.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been added and/or updated, if applicable.
- [ ] Unit tests have been added and/or updated. (If this is not applicable, please provide a justification.)
- [ ] Integration testing has been performed, if applicable

## Description of this Change

Sometimes, Git workflows are cancelled when users make pushes to a branch within a pull request. In that situation, it's possible that an EC2 instance is launched during the first workflow run but never cleaned up. Thus, we could have dangling EC2 instances. Therefore, this change forces the GitHub action to always check if an instance was launched before completing. If an instance was launched, then this action will attempt to get that instance information so that information can be used to tear it down.